### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,8 +921,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ### 🌟 Stargazers Community
 
-[![Stargazers repo roster for @muhittincamdali/iOS-Microservices-Client-Framework](https://starchart.cc/muhittincamdali/iOS-Microservices-Client-Framework.svg)](https://github.com/muhittincamdali/iOS-Microservices-Client-Framework/stargazers)
-
 **⭐ Star this repository if it helped you!**
 
 **💫 Join our amazing community of developers!**


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.