### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,23 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/CachingAPI.md
+- [](&)Documentation/CachingGuide.md
+- [](&)Documentation/CircuitBreakerAPI.md
+- [](&)Documentation/CircuitBreakerGuide.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/LoadBalancerAPI.md
+- [](&)Documentation/LoadBalancingGuide.md
+- [](&)Documentation/MicroservicesClientAPI.md
+- [](&)Documentation/MonitoringAPI.md
+- [](&)Documentation/MonitoringGuide.md
+- [](&)Documentation/ResilienceAPI.md
+- [](&)Documentation/ResilienceGuide.md
+- [](&)Documentation/ServiceDiscoveryAPI.md
+- [](&)Documentation/ServiceDiscoveryGuide.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,8 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedServiceCall.swift
+- ``Examples/BasicExample.swift
+- ``Examples/CachingExamples/CachingExample.swift
+- ``Examples/CircuitBreakerExamples/CircuitBreakerExample.swift
+- ``Examples/ECommerceAppExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.